### PR TITLE
Build with last Android SDK works with aapt workaround.

### DIFF
--- a/orte/contrib/shape_android/AndroidManifest.xml
+++ b/orte/contrib/shape_android/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="10"
-        android:targetSdkVersion="15" />
+        android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/orte/contrib/shape_android/README
+++ b/orte/contrib/shape_android/README
@@ -5,8 +5,8 @@ Shape for Android is a demonstration application delivered with ORTE source code
 
 How to create shape_android.apk
 -----------------------------
-1] Update Android SDK to include Android 4.0.3 (API 15)
-<path-to-sdk>/tools/android update sdk --no-ui --all --filter android-15
+1] Update Android SDK to include last Android 5.0.1 (API 21)
+<path-to-sdk>/tools/android update sdk --no-ui --all --filter android-21
 
 2] Clone ORTE project from git
 git clone git://rtime.felk.cvut.cz/orte
@@ -29,17 +29,15 @@ ant debug
 
 
 ---
-!! Note that in case you haven't renamed the project, in step 7] you should run command:
-<path-to-sdk>/platform-tools/adb install -r bin/PublisherActivity-debug.apk
-
 !! Note that there is kind of problem with aapt for some architectures, when running
 "ant debug" command. On my pc - 32bit, Debian GNU/Linux 7.8 (wheezy), the problem
 was solved in directory <path-to-sdk>/build-tools/21.1.2 like this:
 
 $mv aapt _aapt
-$vi aapt
-#!/bin/bash
-qemu-i386 -cpu n270 -L / <path-to-sdk>/build-tools/21.1.2/_aapt $@
+$cat <<EOF > aapt
+>#!/bin/bash
+>qemu-i386 -cpu n270 -L / <path-to-sdk>/build-tools/21.1.2/_aapt $@
+>EOF
 
-Means that aapt is run in qemu. Build then was sucessful.
+It means that aapt is run in qemu. Build then was sucessful.
 

--- a/orte/contrib/shape_android/project.properties
+++ b/orte/contrib/shape_android/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-15
+target=android-21
 android.library.reference.1=../../libaorte


### PR DESCRIPTION
Dobry den,

toto je zkusebni pull request. Vyzkousel jsem build aplikace shape pro android pres ant s pomoci poslednich build tools a pro cilovou platformu 5.0 tak, jak to ma dle Android Developer's guilde byt. Diky workaroundu s aapt mi toto reseni funguje.

Pekny den,
jiri hubacek