### PR TITLE
Android: update API levels for building

### DIFF
--- a/orte/contrib/Robot_Demo/AndroidManifest.xml
+++ b/orte/contrib/Robot_Demo/AndroidManifest.xml
@@ -5,8 +5,8 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="10"
-        android:targetSdkVersion="15" />
+        android:minSdkVersion="9"
+        android:targetSdkVersion="22" />
     
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>

--- a/orte/contrib/Robot_Demo/project.properties
+++ b/orte/contrib/Robot_Demo/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-15
+target=android-22
 android.library.reference.1=../../libaorte

--- a/orte/contrib/shape_android/AndroidManifest.xml
+++ b/orte/contrib/shape_android/AndroidManifest.xml
@@ -5,8 +5,8 @@
     android:versionName="1.2" >
 
     <uses-sdk
-        android:minSdkVersion="10"
-        android:targetSdkVersion="21" />
+        android:minSdkVersion="9"
+        android:targetSdkVersion="22" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/orte/contrib/shape_android/project.properties
+++ b/orte/contrib/shape_android/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-21
+target=android-22
 android.library.reference.1=../../libaorte

--- a/orte/libaorte/AndroidManifest.xml
+++ b/orte/libaorte/AndroidManifest.xml
@@ -4,8 +4,8 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="10"
-        android:targetSdkVersion="15" />
+        android:minSdkVersion="9"
+        android:targetSdkVersion="22" />
     <uses-permission android:name="android.permission.INTERNET"/>
 
 

--- a/orte/libaorte/project.properties
+++ b/orte/libaorte/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-15
+target=android-22
 android.library=true


### PR DESCRIPTION
Build all components against API level 22 (Android 5.1). Decrement
minSdkVersion, because ORTE needs pthread_rwlock_* and these are provided
since API level 9 (Android 2.3).

This is the recommended setting by Google 
(http://developer.android.com/guide/topics/manifest/uses-sdk-element.html). 
By saying to target the latest API, we prevent invoking compatibility behaviors. 
These behaviors are sometimes buggy (during testing with 'shape_android' after 
interacting with menu items they were duplicated each time I tapped on them).

I tested 'shape_android' on Android 2.3/4.0/4.1/4.3/4.4/5/5.1.